### PR TITLE
Improve reproducibility and portability of `direct-ubuntu.sh`

### DIFF
--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -14,9 +14,11 @@ fi
 
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+# if pyenv is not installed yet, install it
+if [ -d $HOME/.pyenv ]; then
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
-cat << 'EOF' | tee -a $PROFILE | tee /tmp/exports.sh
+    cat << 'EOF' | tee -a $PROFILE | tee /tmp/exports.sh
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init --path)"
@@ -25,7 +27,8 @@ if command -v pyenv 1>/dev/null 2>&1; then
 fi
 EOF
 
-. /tmp/exports.sh
+    . /tmp/exports.sh
+fi
 
 sudo apt -y install libvirt-dev libpython3-dev zlib1g-dev libssl-dev
 

--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -16,16 +16,16 @@ ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
-cat >> $PROFILE << 'EOF'
+cat << 'EOF' | tee -a $PROFILE | tee /tmp/exports.sh
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init --path)"
 if command -v pyenv 1>/dev/null 2>&1; then
     eval "$(pyenv init -)"
-fi'
+fi
 EOF
 
-. ~/.bash_profile
+. /tmp/exports.sh
 
 sudo apt -y install libvirt-dev libpython3-dev zlib1g-dev libssl-dev
 

--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -15,7 +15,7 @@ fi
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 # if pyenv is not installed yet, install it
-if [ -d $HOME/.pyenv ]; then
+if [ ! -d $HOME/.pyenv ]; then
     git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 
     cat << 'EOF' | tee -a $PROFILE | tee /tmp/exports.sh

--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 set -xe
+
+SHELL_NAME="${SHELL##*/}"
+if [ "$SHELL_NAME" = "bash" ]; then
+    PROFILE="$HOME/.bash_profile"
+elif [ "$SHELL_NAME" = "zsh" ]; then
+    PROFILE="$HOME/.zshrc"
+else
+    echo "Unknown shell."
+    echo "Supported shells: bash, zsh"
+    exit 1
+fi
+
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv

--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -27,11 +27,12 @@ EOF
 
 . ~/.bash_profile
 
+sudo apt -y install libvirt-dev libpython3-dev zlib1g-dev libssl-dev
+
 pyenv install 3.8.0
 pyenv global 3.8.0
 pip install pipenv
 
-sudo apt -y install libvirt-dev libpython3-dev
 git clone https://github.com/slankdev/fdk.git
 cd fdk
 pipenv sync

--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -15,10 +15,16 @@ fi
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
-echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
-echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile
-echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+
+cat >> $PROFILE << 'EOF'
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init --path)"
+if command -v pyenv 1>/dev/null 2>&1; then
+    eval "$(pyenv init -)"
+fi'
+EOF
+
 . ~/.bash_profile
 
 pyenv install 3.8.0

--- a/direct-ubuntu.sh
+++ b/direct-ubuntu.sh
@@ -36,7 +36,7 @@ fi
 
 sudo apt -y install libvirt-dev libpython3-dev zlib1g-dev libssl-dev
 
-pyenv install 3.8.0
+pyenv install --skip-existing 3.8.0
 pyenv global 3.8.0
 pip install pipenv
 


### PR DESCRIPTION
I set up my Ubuntu 20.04.3 environment using the official `.iso` file, but some commands in `direct-ubuntu.sh` failed and needed to be modified to run. (Some was because the default `sh` was symlinked to `dash`.)

I modified them and also improved reproducibility to run many times in the same machine.